### PR TITLE
Fix compilation on ubuntu, hopefully without breaking other stuff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,13 @@ CFLAGS=-Wall
 all: hstress hserve hplay
 
 hstress: u.o hstress.o
-	$(CC) $(CFLAGS) $(LDFLAGS) -levent -o $@ $^
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ -levent
 	
 hserve: u.o hserve.o
-	$(CC) $(CFLAGS) $(LDFLAGS) -levent -o $@ $^
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ -levent
 
 hplay: u.o hplay.o
-	$(CC) $(CFLAGS) $(LDFLAGS) -levent -o $@ $^
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ -levent
 
 clean:
 	rm -f hstress hserver hplay *.o


### PR DESCRIPTION
Trying to build on ubuntu 12.04 against libevent-2.0.16-stable-1 gives these `ld` errors:

```
$ make
cc -Wall   -c -o u.o u.c
cc -Wall   -c -o hstress.o hstress.c
hstress.c: In function ‘reportcb’:
hstress.c:103:16: warning: unused variable ‘milliseconds’ [-Wunused-variable]
hstress.c:103:9: warning: unused variable ‘count’ [-Wunused-variable]
hstress.c:102:22: warning: unused variable ‘diff’ [-Wunused-variable]
hstress.c:102:17: warning: unused variable ‘now’ [-Wunused-variable]
hstress.c: In function ‘chldreadcb’:
hstress.c:307:4: warning: implicit declaration of function ‘time’ [-Wimplicit-function-declaration]
hstress.c: In function ‘chlderrcb’:
hstress.c:342:7: warning: unused variable ‘nprocs’ [-Wunused-variable]
hstress.c: In function ‘parentd’:
hstress.c:381:3: warning: implicit declaration of function ‘waitpid’ [-Wimplicit-function-declaration]
hstress.c:356:8: warning: variable ‘pid’ set but not used [-Wunused-but-set-variable]
hstress.c:355:23: warning: unused variable ‘size’ [-Wunused-variable]
hstress.c: In function ‘main’:
hstress.c:447:18: warning: unused variable ‘he’ [-Wunused-variable]
cc -Wall  -levent -o hstress u.o hstress.o
hstress.o: In function `reportcb':
hstress.c:(.text+0x227): undefined reference to `event_add'
hstress.o: In function `mkhttp':
hstress.c:(.text+0x24c): undefined reference to `evhttp_connection_new'
hstress.c:(.text+0x27c): undefined reference to `evhttp_connection_set_closecb'
hstress.o: In function `dispatch':
hstress.c:(.text+0x2e7): undefined reference to `evhttp_request_new'
hstress.c:(.text+0x335): undefined reference to `evhttp_add_header'
hstress.c:(.text+0x36c): undefined reference to `event_set'
hstress.c:(.text+0x381): undefined reference to `event_add'
hstress.c:(.text+0x39b): undefined reference to `evhttp_make_request'
hstress.o: In function `complete':
hstress.c:(.text+0x3f6): undefined reference to `event_del'
hstress.c:(.text+0x5ba): undefined reference to `evhttp_connection_free'
hstress.c:(.text+0x5ea): undefined reference to `event_set'
hstress.c:(.text+0x5fb): undefined reference to `event_add'
hstress.c:(.text+0x610): undefined reference to `evhttp_connection_free'
hstress.c:(.text+0x633): undefined reference to `event_del'
hstress.o: In function `timeoutcb':
hstress.c:(.text+0x6c8): undefined reference to `evhttp_connection_free'
hstress.o: In function `chldreadcb':
hstress.c:(.text+0x73c): undefined reference to `evbuffer_readline'
hstress.c:(.text+0xaac): undefined reference to `bufferevent_enable'
hstress.o: In function `chlderrcb':
hstress.c:(.text+0xaf4): undefined reference to `bufferevent_setcb'
hstress.c:(.text+0xb05): undefined reference to `bufferevent_disable'
hstress.c:(.text+0xb11): undefined reference to `bufferevent_free'
hstress.o: In function `parentd':
hstress.c:(.text+0xbe7): undefined reference to `event_init'
hstress.c:(.text+0xc14): undefined reference to `bufferevent_new'
hstress.c:(.text+0xc29): undefined reference to `bufferevent_enable'
hstress.c:(.text+0xc3e): undefined reference to `event_dispatch'
hstress.o: In function `main':
hstress.c:(.text+0x1408): undefined reference to `event_init'
hstress.c:(.text+0x148e): undefined reference to `event_set'
hstress.c:(.text+0x149d): undefined reference to `event_add'
hstress.c:(.text+0x14a2): undefined reference to `event_dispatch'
collect2: ld returned 1 exit status
make: *** [hstress] Error 1
```

A little googling turned up [this suggestion](http://stackoverflow.com/a/6901215/397334) to reorder the `-levent` flag, which makes things work for me:

```
make
cc -Wall   -c -o u.o u.c
cc -Wall   -c -o hstress.o hstress.c
hstress.c: In function ‘reportcb’:
hstress.c:103:16: warning: unused variable ‘milliseconds’ [-Wunused-variable]
hstress.c:103:9: warning: unused variable ‘count’ [-Wunused-variable]
hstress.c:102:22: warning: unused variable ‘diff’ [-Wunused-variable]
hstress.c:102:17: warning: unused variable ‘now’ [-Wunused-variable]
hstress.c: In function ‘chldreadcb’:
hstress.c:307:4: warning: implicit declaration of function ‘time’ [-Wimplicit-function-declaration]
hstress.c: In function ‘chlderrcb’:
hstress.c:342:7: warning: unused variable ‘nprocs’ [-Wunused-variable]
hstress.c: In function ‘parentd’:
hstress.c:381:3: warning: implicit declaration of function ‘waitpid’ [-Wimplicit-function-declaration]
hstress.c:356:8: warning: variable ‘pid’ set but not used [-Wunused-but-set-variable]
hstress.c:355:23: warning: unused variable ‘size’ [-Wunused-variable]
hstress.c: In function ‘main’:
hstress.c:447:18: warning: unused variable ‘he’ [-Wunused-variable]
cc -Wall  -o hstress u.o hstress.o -levent
cc -Wall   -c -o hserve.o hserve.c
hserve.c: In function ‘serve’:
hserve.c:22:30: warning: unused variable ‘sock’ [-Wunused-variable]
cc -Wall  -o hserve u.o hserve.o -levent
cc -Wall   -c -o hplay.o hplay.c
hplay.c: In function ‘readrequest’:
hplay.c:244:9: warning: variable ‘clen’ set but not used [-Wunused-but-set-variable]
cc -Wall  -o hplay u.o hplay.o -levent
```

Sounds like maybe @trustin was having similar issues? https://twitter.com/trustin/status/321369977154334720
